### PR TITLE
feat: Add Reset Button and disable selections based on other selections

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -5,7 +5,7 @@ import Css exposing (hover)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
-import Model exposing (Model, ensureLimit2DShapes, ensureNoIllegalSelections, ensureUniqueInsideShapes, initModel, selected2Dshapes, selected3Dshapes, solveShapes)
+import Model exposing (Model, ensureNoIllegalSelections, initModel, selected2Dshapes, selected3Dshapes, solveShapes)
 import Msg exposing (Msg(..))
 import Shapes exposing (Shape2D, Shape3D)
 import Statues.Internal exposing (Position(..))
@@ -44,21 +44,17 @@ newSelectionOutside shape selection =
     { selection | outsideShape = Just shape }
 
 
-updateSelections : Model -> Position -> (Position -> Model -> Model) -> Model.StatueSelection -> Model
-updateSelections model pos ensure newSelection =
-    let
-        verify =
-            ensure pos
-    in
+updateSelections : Model -> Position -> Model.StatueSelection -> Model
+updateSelections model pos newSelection =
     case pos of
         Left ->
-            verify { model | leftStatueSelections = newSelection }
+            { model | leftStatueSelections = newSelection }
 
         Middle ->
-            verify { model | middleStatueSelections = newSelection }
+            { model | middleStatueSelections = newSelection }
 
         Right ->
-            verify { model | rightStatueSelections = newSelection }
+            { model | rightStatueSelections = newSelection }
 
 
 update : Msg -> Model -> Model
@@ -70,10 +66,10 @@ update msg model =
         newModel =
             case msg of
                 SelectionInside pos shape ->
-                    (getSelection pos >> newSelectionInside shape >> updateModel pos (\p -> \m -> m)) model
+                    (getSelection pos >> newSelectionInside shape >> updateModel pos) model
 
                 SelectionOutside pos shape ->
-                    (getSelection pos >> newSelectionOutside shape >> updateModel pos ensureLimit2DShapes) model
+                    (getSelection pos >> newSelectionOutside shape >> updateModel pos) model
 
                 ResetSelections ->
                     initModel

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -5,7 +5,7 @@ import Css exposing (hover)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
-import Model exposing (Model, ensureLimit2DShapes, ensureNoIllegalSelections, ensureUniqueInsideShapes, initModel, selected2Dshapes, solveShapes)
+import Model exposing (Model, ensureLimit2DShapes, ensureNoIllegalSelections, ensureUniqueInsideShapes, initModel, selected2Dshapes, selected3Dshapes, solveShapes)
 import Msg exposing (Msg(..))
 import Shapes exposing (Shape2D, Shape3D)
 import Statues.Internal exposing (Position(..))
@@ -90,8 +90,11 @@ view model =
         selectedInsideShapes =
             selected2Dshapes model
 
+        selectedOutsideShapes =
+            selected3Dshapes model
+
         viewStatue =
-            renderStatue selectedInsideShapes
+            renderStatue selectedInsideShapes selectedOutsideShapes
     in
     div
         [ css

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -118,6 +118,8 @@ view model =
                     [ css
                         [ Tw.bg_color Theme.blue_500
                         , hover [ Tw.bg_color Theme.blue_700 ]
+                        , Tw.border
+                        , Tw.border_color Theme.blue_700
                         , Tw.text_color Theme.white
                         , Tw.font_bold
                         , Tw.py_2

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -113,7 +113,7 @@ view model =
                 ]
                 [ h1 [] [ text "Salvation's Edge Fourth Encounter: Verity" ] ]
             , div
-                [ css [ Tw.flex, Tw.flex_col, Tw.gap_5 ] ]
+                [ css [ Tw.flex, Tw.flex_col, Tw.gap_5, Tw.items_center ] ]
                 [ button
                     [ css
                         [ Tw.bg_color Theme.blue_500

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -5,7 +5,7 @@ import Css exposing (hover)
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
-import Model exposing (Model, ensureLimit2DShapes, ensureNoIllegalSelections, ensureUniqueInsideShapes, initModel, solveShapes)
+import Model exposing (Model, ensureLimit2DShapes, ensureNoIllegalSelections, ensureUniqueInsideShapes, initModel, selected2Dshapes, solveShapes)
 import Msg exposing (Msg(..))
 import Shapes exposing (Shape2D, Shape3D)
 import Statues.Internal exposing (Position(..))
@@ -70,7 +70,7 @@ update msg model =
         newModel =
             case msg of
                 SelectionInside pos shape ->
-                    (getSelection pos >> newSelectionInside shape >> updateModel pos ensureUniqueInsideShapes) model
+                    (getSelection pos >> newSelectionInside shape >> updateModel pos (\p -> \m -> m)) model
 
                 SelectionOutside pos shape ->
                     (getSelection pos >> newSelectionOutside shape >> updateModel pos ensureLimit2DShapes) model
@@ -86,6 +86,13 @@ update msg model =
 
 view : Model -> Html Msg
 view model =
+    let
+        selectedInsideShapes =
+            selected2Dshapes model
+
+        viewStatue =
+            renderStatue selectedInsideShapes
+    in
     div
         [ css
             [ Tw.bg_color Theme.zinc_900
@@ -114,9 +121,9 @@ view model =
                 [ css [ Tw.flex, Tw.flex_col, Tw.gap_5 ] ]
                 [ div
                     [ css [ Tw.flex, Tw.flex_wrap, Tw.flex_row, Tw.gap_10 ] ]
-                    [ renderStatue Left model.leftStatueSelections
-                    , renderStatue Middle model.middleStatueSelections
-                    , renderStatue Right model.rightStatueSelections
+                    [ viewStatue Left model.leftStatueSelections
+                    , viewStatue Middle model.middleStatueSelections
+                    , viewStatue Right model.rightStatueSelections
                     ]
                 , button
                     [ css
@@ -136,8 +143,23 @@ view model =
                     [ text "Reset Selections" ]
                 ]
             , div
-                [ css [ Tw.flex, Tw.flex_wrap, Tw.py_12, Tw.flex_col, Tw.justify_center, Tw.gap_10 ] ]
-                (renderSteps model.steps)
+                [ css
+                    [ Tw.flex
+                    , Tw.flex_wrap
+                    , Tw.py_12
+                    , Tw.flex_col
+                    , Tw.justify_center
+                    , Tw.gap_10
+                    ]
+                ]
+              <|
+                renderSteps model.steps
             ]
-        , footer [ css [ Tw.flex, Tw.justify_center ] ] [ p [] [ text "Created by GoldenGod#1001" ] ]
+        , footer
+            [ css
+                [ Tw.flex
+                , Tw.justify_center
+                ]
+            ]
+            [ p [] [ text "Created by GoldenGod#1001" ] ]
         ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,9 +1,12 @@
 module Main exposing (main)
 
 import Browser
+import Css exposing (hover)
 import Dict exposing (update)
+import Html
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
+import Html.Styled.Events exposing (onClick)
 import Model exposing (Model, ensureLimit2DShapes, ensureNoIllegalSelections, ensureUniqueInsideShapes, initModel, solveShapes)
 import Msg exposing (Msg(..))
 import Shapes exposing (Shape2D, Shape3D)
@@ -74,6 +77,9 @@ update msg model =
                 SelectionOutside pos shape ->
                     (getSelection pos >> newSelectionOutside shape >> updateModel pos ensureLimit2DShapes) model
 
+                ResetSelections ->
+                    initModel
+
                 NoOp ->
                     model
     in
@@ -107,10 +113,26 @@ view model =
                 ]
                 [ h1 [] [ text "Salvation's Edge Fourth Encounter: Verity" ] ]
             , div
-                [ css [ Tw.flex, Tw.flex_wrap, Tw.flex_row, Tw.justify_center, Tw.gap_10 ] ]
-                [ renderStatue Left model.leftStatueSelections
-                , renderStatue Middle model.middleStatueSelections
-                , renderStatue Right model.rightStatueSelections
+                [ css [ Tw.flex, Tw.flex_col, Tw.gap_5 ] ]
+                [ button
+                    [ css
+                        [ Tw.bg_color Theme.blue_500
+                        , hover [ Tw.bg_color Theme.blue_700 ]
+                        , Tw.text_color Theme.white
+                        , Tw.font_bold
+                        , Tw.py_2
+                        , Tw.px_4
+                        , Tw.rounded
+                        ]
+                    , onClick ResetSelections
+                    ]
+                    [ text "Reset Selections" ]
+                , div
+                    [ css [ Tw.flex, Tw.flex_wrap, Tw.flex_row, Tw.justify_center, Tw.gap_10 ] ]
+                    [ renderStatue Left model.leftStatueSelections
+                    , renderStatue Middle model.middleStatueSelections
+                    , renderStatue Right model.rightStatueSelections
+                    ]
                 ]
             , div
                 [ css [ Tw.flex, Tw.flex_wrap, Tw.py_12, Tw.flex_col, Tw.justify_center, Tw.gap_10 ] ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -92,7 +92,7 @@ view model =
         viewStatue =
             renderStatue selectedInsideShapes selectedOutsideShapes
     in
-    div
+    main_
         [ css
             [ Tw.bg_color Theme.zinc_900
             , Bp.xxl [ Tw.px_80 ]
@@ -106,7 +106,7 @@ view model =
             , Tw.text_color Theme.white
             ]
         ]
-        [ main_ [ css [ Tw.flex, Tw.flex_col, Tw.items_center ] ]
+        [ div [ css [ Tw.flex, Tw.flex_col, Tw.items_center ] ]
             [ section
                 [ css
                     [ Tw.text_5xl

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,8 +2,6 @@ module Main exposing (main)
 
 import Browser
 import Css exposing (hover)
-import Dict exposing (update)
-import Html
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
@@ -102,7 +100,7 @@ view model =
             , Tw.text_color Theme.white
             ]
         ]
-        [ main_ []
+        [ main_ [ css [ Tw.flex, Tw.flex_col, Tw.items_center ] ]
             [ section
                 [ css
                     [ Tw.text_5xl
@@ -113,8 +111,14 @@ view model =
                 ]
                 [ h1 [] [ text "Salvation's Edge Fourth Encounter: Verity" ] ]
             , div
-                [ css [ Tw.flex, Tw.flex_col, Tw.gap_5, Tw.items_center ] ]
-                [ button
+                [ css [ Tw.flex, Tw.flex_col, Tw.gap_5 ] ]
+                [ div
+                    [ css [ Tw.flex, Tw.flex_wrap, Tw.flex_row, Tw.gap_10 ] ]
+                    [ renderStatue Left model.leftStatueSelections
+                    , renderStatue Middle model.middleStatueSelections
+                    , renderStatue Right model.rightStatueSelections
+                    ]
+                , button
                     [ css
                         [ Tw.bg_color Theme.blue_500
                         , hover [ Tw.bg_color Theme.blue_700 ]
@@ -125,16 +129,11 @@ view model =
                         , Tw.py_2
                         , Tw.px_4
                         , Tw.rounded
+                        , Tw.text_xl
                         ]
                     , onClick ResetSelections
                     ]
                     [ text "Reset Selections" ]
-                , div
-                    [ css [ Tw.flex, Tw.flex_wrap, Tw.flex_row, Tw.justify_center, Tw.gap_10 ] ]
-                    [ renderStatue Left model.leftStatueSelections
-                    , renderStatue Middle model.middleStatueSelections
-                    , renderStatue Right model.rightStatueSelections
-                    ]
                 ]
             , div
                 [ css [ Tw.flex, Tw.flex_wrap, Tw.py_12, Tw.flex_col, Tw.justify_center, Tw.gap_10 ] ]

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -1,4 +1,4 @@
-module Model exposing (Model, StatueSelection, ensureLimit2DShapes, ensureNoIllegalSelections, ensureUniqueInsideShapes, initModel, selected2Dshapes, selected3Dshapes, solveShapes)
+module Model exposing (Model, StatueSelection, ensureLimit2DShapes, ensureNoIllegalSelections, ensureUniqueInsideShapes, initModel, maxNumberOf2DShapes, numberOfCircles, numberOfSquares, numberOfTriangles, selected2Dshapes, selected3Dshapes, solveShapes)
 
 import Calculator exposing (orderToSolve)
 import Shapes exposing (Shape2D(..), Shape3D(..), isIllegalShapeToStart)

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -1,4 +1,4 @@
-module Model exposing (Model, StatueSelection, ensureLimit2DShapes, ensureNoIllegalSelections, ensureUniqueInsideShapes, initModel, maxNumberOf2DShapes, numberOfCircles, numberOfSquares, numberOfTriangles, selected2Dshapes, selected3Dshapes, solveShapes)
+module Model exposing (Model, StatueSelection, ensureNoIllegalSelections, initModel, maxNumberOf2DShapes, numberOfCircles, numberOfSquares, numberOfTriangles, selected2Dshapes, selected3Dshapes, solveShapes)
 
 import Calculator exposing (orderToSolve)
 import Shapes exposing (Shape2D(..), Shape3D(..), isIllegalShapeToStart)
@@ -160,54 +160,6 @@ ensureNoIllegalSelections model =
     }
 
 
-ensureLimit2DShapes : Position -> Model -> Model
-ensureLimit2DShapes posToIgnore model =
-    let
-        selections =
-            List.filterMap identity [ model.leftStatueSelections.outsideShape, model.middleStatueSelections.outsideShape, model.rightStatueSelections.outsideShape ]
-
-        verifySelections =
-            ensureOrIgnoreShape (ensureLimts selections) posToIgnore
-    in
-    { model
-        | leftStatueSelections =
-            verifySelections Left model.leftStatueSelections
-        , middleStatueSelections =
-            verifySelections Middle model.middleStatueSelections
-        , rightStatueSelections =
-            verifySelections Right model.rightStatueSelections
-    }
-
-
-ensureLimts : List Shape3D -> StatueSelection -> StatueSelection
-ensureLimts shapes selection =
-    let
-        condition =
-            case selection.outsideShape of
-                Just Sphere ->
-                    numberOfCircles shapes > maxNumberOf2DShapes
-
-                Just Cube ->
-                    numberOfSquares shapes > maxNumberOf2DShapes
-
-                Just Pyramid ->
-                    numberOfTriangles shapes > maxNumberOf2DShapes
-
-                Just Cone ->
-                    numberOfTriangles shapes > maxNumberOf2DShapes || numberOfCircles shapes > maxNumberOf2DShapes
-
-                Just Cylinder ->
-                    numberOfCircles shapes > maxNumberOf2DShapes || numberOfSquares shapes > maxNumberOf2DShapes
-
-                Just Prism ->
-                    numberOfTriangles shapes > maxNumberOf2DShapes || numberOfSquares shapes > maxNumberOf2DShapes
-
-                Nothing ->
-                    False
-    in
-    ensureOutsideSelection selection condition
-
-
 ensureOutsideSelection : StatueSelection -> Bool -> StatueSelection
 ensureOutsideSelection selection condition =
     if condition then
@@ -215,45 +167,3 @@ ensureOutsideSelection selection condition =
 
     else
         selection
-
-
-ensureOrIgnoreShape : (StatueSelection -> StatueSelection) -> Position -> Position -> StatueSelection -> StatueSelection
-ensureOrIgnoreShape transform ignorePos pos selection =
-    if pos == ignorePos then
-        selection
-
-    else
-        transform selection
-
-
-ensureUniqueInsideShapes : Position -> Model -> Model
-ensureUniqueInsideShapes posToIgnore model =
-    let
-        selections =
-            selected2Dshapes model
-
-        verifySelections =
-            ensureOrIgnoreShape (ensureUniqueShapes2D selections) posToIgnore
-    in
-    { model
-        | leftStatueSelections =
-            verifySelections Left model.leftStatueSelections
-        , middleStatueSelections =
-            verifySelections Middle model.middleStatueSelections
-        , rightStatueSelections =
-            verifySelections Right model.rightStatueSelections
-    }
-
-
-ensureUniqueShapes2D : List Shape2D -> StatueSelection -> StatueSelection
-ensureUniqueShapes2D shapes shapesSelected =
-    case shapesSelected.insideShape of
-        Just s ->
-            if List.length (List.filter ((==) s) shapes) > 1 then
-                emptySelection
-
-            else
-                shapesSelected
-
-        Nothing ->
-            shapesSelected

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -230,7 +230,7 @@ ensureUniqueInsideShapes : Position -> Model -> Model
 ensureUniqueInsideShapes posToIgnore model =
     let
         selections =
-            List.filterMap identity [ model.leftStatueSelections.insideShape, model.middleStatueSelections.insideShape, model.rightStatueSelections.insideShape ]
+            selected2Dshapes model
 
         verifySelections =
             ensureOrIgnoreShape (ensureUniqueShapes2D selections) posToIgnore

--- a/src/Msg.elm
+++ b/src/Msg.elm
@@ -7,4 +7,5 @@ import Statues.Internal exposing (Position(..))
 type Msg
     = SelectionInside Position Shape2D
     | SelectionOutside Position Shape3D
+    | ResetSelections
     | NoOp

--- a/src/Statues.elm
+++ b/src/Statues.elm
@@ -11,9 +11,9 @@ type alias Statue =
     }
 
 
-isComplete : Statue -> Bool
-isComplete statue =
-    case ( statue.insideShape, statue.outsideShape ) of
+isComplete : Shape2D -> Shape3D -> Bool
+isComplete inside outside =
+    case ( inside, outside ) of
         ( Circle, Prism ) ->
             True
 

--- a/src/Steps.elm
+++ b/src/Steps.elm
@@ -10,7 +10,7 @@ generateSteps statues =
         [ s1, s2, s3 ] ->
             case generateStep s1 s2 of
                 Just ( step1, step2 ) ->
-                    if isComplete step1.statueAfterDissect then
+                    if isComplete step1.statueAfterDissect.insideShape step1.statueAfterDissect.outsideShape then
                         ( step1, step2 ) :: generateSteps [ { s2 | outsideShape = step2.statueAfterDissect.outsideShape }, s3 ]
 
                     else
@@ -19,7 +19,7 @@ generateSteps statues =
                 Nothing ->
                     case generateStep s1 s3 of
                         Just ( step1, step3 ) ->
-                            if isComplete step1.statueAfterDissect then
+                            if isComplete step1.statueAfterDissect.insideShape step1.statueAfterDissect.outsideShape then
                                 ( step1, step3 ) :: generateSteps [ s2, { s3 | outsideShape = step3.statueAfterDissect.outsideShape } ]
 
                             else

--- a/src/View/Statues.elm
+++ b/src/View/Statues.elm
@@ -32,7 +32,7 @@ radioButton isSelected isDisabled position message className name =
             , Html.name className
             , Html.id id
             , Html.checked isSelected
-            , Html.disabled isDisabled
+            , Html.disabled (not isSelected && isDisabled)
             , onCheck
                 (\checked ->
                     if checked then
@@ -84,8 +84,8 @@ radioButtonGroup =
         ]
 
 
-radioButtonGroupInnerStatue : Position -> Maybe Shape2D -> Html Msg
-radioButtonGroupInnerStatue position selectedShape =
+radioButtonGroupInnerStatue : List Shape2D -> Position -> Maybe Shape2D -> Html Msg
+radioButtonGroupInnerStatue selectedShapes position selectedShape =
     let
         shapes =
             [ Circle, Square, Triangle ]
@@ -103,8 +103,11 @@ radioButtonGroupInnerStatue position selectedShape =
                     isSelected =
                         Maybe.withDefault False <|
                             Maybe.map (\s -> s == shape) selectedShape
+
+                    isDisabled =
+                        List.member shape selectedShapes
                 in
-                radioButton isSelected False position (messageHandler shape) radioButtonClass (toString2D shape)
+                radioButton isSelected isDisabled position (messageHandler shape) radioButtonClass (toString2D shape)
             )
             shapes
 
@@ -135,11 +138,37 @@ radioButtonGroupOuterStatue position selectedShapeInside selectedShapeOutside sh
             shapes
 
 
-renderStatue : Position -> StatueSelection -> Html Msg
-renderStatue position statueSelections =
-    div [ css [ Tw.text_color Theme.white, Tw.bg_color Theme.zinc_700, Tw.px_3, Tw.py_2, Tw.border_solid, Tw.border_2, Tw.rounded, Tw.border_color Theme.slate_400 ] ]
+renderStatue : List Shape2D -> Position -> StatueSelection -> Html Msg
+renderStatue selectedInsideShapes position statueSelections =
+    div
+        [ css
+            [ Tw.text_color Theme.white
+            , Tw.bg_color Theme.zinc_700
+            , Tw.px_3
+            , Tw.py_2
+            , Tw.border_solid
+            , Tw.border_2
+            , Tw.rounded
+            , Tw.border_color Theme.slate_400
+            ]
+        ]
         [ h2 [] [ toString position |> text ]
-        , div [ css [ Tw.flex ] ] [ div [ css [ Tw.py_2 ] ] [ Html.p [ css [ Tw.my_1, Tw.text_xl ] ] [ text "Inside Shape" ], radioButtonGroupInnerStatue position statueSelections.insideShape ] ]
+        , div
+            [ css [ Tw.flex ] ]
+            [ div
+                [ css [ Tw.py_2 ] ]
+                [ Html.p [ css [ Tw.my_1, Tw.text_xl ] ] [ text "Inside Shape" ]
+                , radioButtonGroupInnerStatue selectedInsideShapes position statueSelections.insideShape
+                ]
+            ]
         , hr [] []
-        , div [ css [ Tw.flex ] ] [ div [ css [ Tw.py_2 ] ] [ Html.p [ css [ Tw.my_1, Tw.text_xl ] ] [ text "Outside Shape" ], radioButtonGroupOuterStatue position statueSelections.insideShape statueSelections.outsideShape [ Sphere, Cube, Pyramid ], radioButtonGroupOuterStatue position statueSelections.insideShape statueSelections.outsideShape [ Prism, Cone, Cylinder ] ] ]
+        , div
+            [ css [ Tw.flex ] ]
+            [ div
+                [ css [ Tw.py_2 ] ]
+                [ Html.p [ css [ Tw.my_1, Tw.text_xl ] ] [ text "Outside Shape" ]
+                , radioButtonGroupOuterStatue position statueSelections.insideShape statueSelections.outsideShape [ Sphere, Cube, Pyramid ]
+                , radioButtonGroupOuterStatue position statueSelections.insideShape statueSelections.outsideShape [ Prism, Cone, Cylinder ]
+                ]
+            ]
         ]

--- a/src/View/Steps.elm
+++ b/src/View/Steps.elm
@@ -54,7 +54,7 @@ renderShapesAfterStep ( statue1, statue2 ) =
             div []
                 [ Html.p []
                     [ text <| toString statue1.statueAfterDissect.position ++ " --> " ++ toString3D statue1.statueAfterDissect.outsideShape ]
-                , if isComplete statue1.statueAfterDissect then
+                , if isComplete statue1.statueAfterDissect.insideShape statue2.statueAfterDissect.outsideShape then
                     Html.p []
                         [ text <| toString statue1.statueAfterDissect.position ++ " is done!"
                         ]
@@ -69,7 +69,7 @@ renderShapesAfterStep ( statue1, statue2 ) =
                     []
                     [ text <| toString statue2.statueAfterDissect.position ++ " --> " ++ toString3D statue2.statueAfterDissect.outsideShape
                     ]
-                , if isComplete statue2.statueAfterDissect then
+                , if isComplete statue2.statueAfterDissect.insideShape statue2.statueAfterDissect.outsideShape then
                     Html.p []
                         [ text <| toString statue2.statueAfterDissect.position ++ " is done!"
                         ]

--- a/src/View/Steps.elm
+++ b/src/View/Steps.elm
@@ -54,7 +54,7 @@ renderShapesAfterStep ( statue1, statue2 ) =
             div []
                 [ Html.p []
                     [ text <| toString statue1.statueAfterDissect.position ++ " --> " ++ toString3D statue1.statueAfterDissect.outsideShape ]
-                , if isComplete statue1.statueAfterDissect.insideShape statue2.statueAfterDissect.outsideShape then
+                , if isComplete statue1.statueAfterDissect.insideShape statue1.statueAfterDissect.outsideShape then
                     Html.p []
                         [ text <| toString statue1.statueAfterDissect.position ++ " is done!"
                         ]


### PR DESCRIPTION
Before, to ensure no illegal selections could be made there is logic in place when the model is updated to unselect any choices that would be illegal. For a better UX, have selections be disabled base don what first inputted and allow the form to be reset by clicking a button 