### PR TITLE
fix(orderToSolve): order by position 

### DIFF
--- a/src/Calculator/Internal.elm
+++ b/src/Calculator/Internal.elm
@@ -24,9 +24,9 @@ numberOfStepsToCompelete insideShape outsideShape =
 positionOrder : Position -> Int
 positionOrder pos = 
     case pos of
-        Left -> 1
+        Left -> 3
         Middle -> 2
-        Right -> 3
+        Right -> 1
 
 
 compareStatues : Statue -> Statue -> Order
@@ -44,5 +44,5 @@ compareStatues s1 s2 =
         stepsCompare = compare steps1 steps2
     in
     case stepsCompare of
-        EQ -> compare position1 position2
+        EQ -> compare position2 position1
         _ -> stepsCompare

--- a/src/Calculator/Internal.elm
+++ b/src/Calculator/Internal.elm
@@ -2,6 +2,8 @@ module Calculator.Internal exposing (compareStatues)
 
 import Shapes exposing (Shape2D(..), Shape3D(..))
 import Statues exposing (Statue)
+import Statues.Internal exposing (Position)
+import Statues.Internal exposing (Position(..))
 
 
 numberOfStepsToCompelete : Shape2D -> Shape3D -> Int
@@ -19,6 +21,13 @@ numberOfStepsToCompelete insideShape outsideShape =
         _ ->
             1
 
+positionOrder : Position -> Int
+positionOrder pos = 
+    case pos of
+        Left -> 1
+        Middle -> 2
+        Right -> 3
+
 
 compareStatues : Statue -> Statue -> Order
 compareStatues s1 s2 =
@@ -28,5 +37,12 @@ compareStatues s1 s2 =
 
         steps2 =
             numberOfStepsToCompelete s2.insideShape s2.outsideShape
+
+        position1 = positionOrder s1.position
+        position2 = positionOrder s2.position
+
+        stepsCompare = compare steps1 steps2
     in
-    compare steps1 steps2
+    case stepsCompare of
+        EQ -> compare position1 position2
+        _ -> stepsCompare

--- a/tests/CalculatorTests.elm
+++ b/tests/CalculatorTests.elm
@@ -98,17 +98,17 @@ orderToSolveTests =
             \_ ->
                 let
                     order =
-                        [ { insideShape = Circle
-                          , outsideShape = Sphere
-                          , position = Left
+                        [ { insideShape = Triangle 
+                          , outsideShape = Prism
+                          , position = Right
                           }
                         , { insideShape = Square
                           , outsideShape = Prism
                           , position = Middle
                           }
-                        , { insideShape = Triangle
-                          , outsideShape = Prism
-                          , position = Right
+                        , { insideShape = Circle
+                          , outsideShape = Sphere
+                          , position = Left
                           }
                         ]
                             |> orderToSolve
@@ -152,7 +152,7 @@ orderToSolveTests =
                     order =
                         [ { insideShape = Triangle
                           , outsideShape = Cone
-                          , position = Left
+                          , position = Right
                           }
                         , { insideShape = Square
                           , outsideShape = Cube
@@ -160,7 +160,7 @@ orderToSolveTests =
                           }
                         , { insideShape = Circle
                           , outsideShape = Cone
-                          , position = Right
+                          , position = Left
                           }
                         ]
                             |> orderToSolve

--- a/tests/CalculatorTests.elm
+++ b/tests/CalculatorTests.elm
@@ -172,4 +172,53 @@ orderToSolveTests =
 
                     _ ->
                         Expect.fail "Order should be Left, Right, Middle"
+        , test "should re order to L, M, R when number of steps are the same (2)" <|
+            \_ ->
+                let 
+                    order =
+                        [ { insideShape = Triangle
+                          , outsideShape = Pyramid
+                          , position = Middle
+                          }
+                        , { insideShape = Square
+                          , outsideShape = Cube
+                          , position = Right
+                          }
+                        , { insideShape = Circle
+                          , outsideShape = Sphere
+                          , position = Left
+                          }
+                        ]
+                            |> orderToSolve
+                            |> List.map (\s -> s.position)
+                in
+                    case order of
+                        [Left, Middle, Right] ->
+                            Expect.pass
+                        _ -> Expect.fail "Order should be Left, Mid, Right"
+
+        , test "should re order to L, M, R when number of steps are the same (1)" <|
+            \_ ->
+                let 
+                    order =
+                        [ { insideShape = Square
+                          , outsideShape = Cylinder
+                          , position = Middle
+                          }
+                        , { insideShape = Triangle
+                          , outsideShape = Prism
+                          , position = Right
+                          }
+                        , { insideShape = Circle
+                          , outsideShape = Cone
+                          , position = Left
+                          }
+                        ]
+                            |> orderToSolve
+                            |> List.map (\s -> s.position)
+                in
+                    case order of
+                        [Left, Middle, Right] ->
+                            Expect.pass
+                        _ -> Expect.fail "Order should be Left, Mid, Right"
         ]

--- a/tests/StepsTests.elm
+++ b/tests/StepsTests.elm
@@ -112,32 +112,11 @@ generateSingleStepTests =
         
 statuesOrdered1 : List Statue
 statuesOrdered1 = 
-    [   { insideShape = Circle, outsideShape = Sphere, position = Left }
-    ,   { insideShape = Square, outsideShape = Prism, position = Middle }
+    [   { insideShape = Square, outsideShape = Prism, position = Middle }
     ,   { insideShape = Triangle, outsideShape = Prism, position = Right }
+    ,   { insideShape = Circle, outsideShape = Sphere, position = Left }
     ]
 
-expectedSteps1 : List Step
-expectedSteps1 = 
-    [
-        (
-            { shapeToDissect = Square
-            , statueAfterDissect = { insideShape = Square, outsideShape = Cone, position = Middle } 
-            }
-        ,   { shapeToDissect = Circle
-            , statueAfterDissect = { insideShape = Circle, outsideShape = Cylinder, position = Left } 
-            }
-        )
-        ,
-        (
-            { shapeToDissect = Triangle
-            , statueAfterDissect = { insideShape = Triangle, outsideShape = Cylinder, position = Right } 
-            }
-        ,   { shapeToDissect = Circle
-            , statueAfterDissect = { insideShape = Circle, outsideShape = Prism, position = Left } 
-            }
-        )
-    ]
 statuesOrdered2 : List Statue
 statuesOrdered2 = 
     [   { insideShape = Circle, outsideShape = Sphere, position = Left }
@@ -155,7 +134,17 @@ generateStepsTest =
                                 steps = generateSteps statuesOrdered1 
                             in
                                 case steps of
-                                    [_,_] -> Expect.pass
+                                    [step1, step2] -> 
+                                        let
+                                            (statue1, statue2) = step1
+                                            (statue11, statue22) = step2
+                                        in
+                                            case ((statue1.statueAfterDissect.position, statue1.shapeToDissect, statue1.statueAfterDissect.outsideShape), (statue2.statueAfterDissect.position, statue2.shapeToDissect, statue2.statueAfterDissect.outsideShape)) of 
+                                                ((Middle, Square, Cone), (Left, Circle, Cylinder)) -> 
+                                                    case ((statue11.statueAfterDissect.position, statue11.shapeToDissect, statue11.statueAfterDissect.outsideShape), (statue22.statueAfterDissect.position, statue22.shapeToDissect, statue22.statueAfterDissect.outsideShape)) of
+                                                        ((Right, Triangle, Cylinder), (Left, Circle, Prism)) -> Expect.pass
+                                                        _ -> Expect.fail "it should dissect a triangle off of right and cirlce off of left"
+                                                _ -> Expect.fail "it should dissect a square off of middle and cirlce off of left"
                                     _ -> Expect.fail "it should generate only 2 steps"
                         )
 
@@ -167,8 +156,24 @@ generateStepsTest =
                                 steps = generateSteps statuesOrdered2
                             in
                                 case steps of
-                                    [_,_,_] -> Expect.pass
+                                    [step1, step2 , step3] -> 
+                                        let
+                                            (statue1, statue2) = step1
+                                            (statue11, statue22) = step2
+                                            (statue111, statue222) = step3
+                                        in
+                                            case ((statue1.statueAfterDissect.position, statue1.shapeToDissect, statue1.statueAfterDissect.outsideShape), (statue2.statueAfterDissect.position, statue2.shapeToDissect, statue2.statueAfterDissect.outsideShape)) of
+                                                ((Left, Circle, Cylinder), (Middle, Square, Cylinder)) -> 
+                                                    case ((statue11.statueAfterDissect.position, statue11.shapeToDissect, statue11.statueAfterDissect.outsideShape), (statue22.statueAfterDissect.position, statue22.shapeToDissect, statue22.statueAfterDissect.outsideShape)) of
+                                                        ((Left, Circle, Prism), (Right, Triangle, Cone)) -> 
+                                                            case ((statue111.statueAfterDissect.position, statue111.shapeToDissect, statue111.statueAfterDissect.outsideShape), (statue222.statueAfterDissect.position, statue222.shapeToDissect, statue222.statueAfterDissect.outsideShape)) of
+                                                                ((Middle, Square, Cone), (Right, Triangle, Cylinder)) -> Expect.pass
+                                                                _ -> Expect.fail "it should dissect a sqaure off of middle and a triangle off of right"
+                                                        _ -> Expect.fail "it should dissect a circle off of left and a triangle off of right"
+                                                _ -> Expect.fail "it should dissect a circle off of left and square off of middle"
+                                        
                                     _ -> Expect.fail "it should generate only 3 steps"
+
                             
                         )
                 ]


### PR DESCRIPTION
When sorting the list of statues based on the number of steps to complete, we can get scenarios where two statues have the same number of steps (or all three), in these scenarios we will then sort based on the position. We will prioritize the positions as follows:

Left > Middle > Right 